### PR TITLE
Static systemstat

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["cdylib"]
 [dependencies]
 dirs = "4.0.0"
 hostname = "0.3.1"
+lazy_static = "1.4.0"
 # Default enable napi4 feature, see https://nodejs.org/api/n-api.html#node-api-version-matrix
 napi = { version = "2.6.0", default-features = false, features = ["napi8"] }
 napi-derive = "2.6.0"

--- a/benchmarks/fs/node-fs.mjs
+++ b/benchmarks/fs/node-fs.mjs
@@ -54,7 +54,7 @@ const output = await run();
 writeFile(join(__dirname, 'outputs', 'node-fs.json'), JSON.stringify(output));
 
 // Cleanup
-await rmdir(copyDirPathEmpty, { recrusive: true });
+await rmdir(copyDirPathEmpty, { recursive: true });
 await rmdir(copyDirPathWithFiles, { recursive: true });
 await rmdir(join(__dirname, 'test-copyfile'), { recursive: true });
 await rmdir(join(__dirname, 'test-copyfile-destination'), { recursive: true });

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,2 @@
-tab_spaces = 2
+tab_spaces = 4
 edition = "2021"

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,7 +1,7 @@
-use std::{io, path::Path, fs};
+use std::{fs, io, path::Path};
 
 #[napi(object)]
-pub struct RecrusiveOptions {
+pub struct Recursive {
     pub recursive: Option<bool>,
 }
 
@@ -12,46 +12,39 @@ pub struct CopyDirOptions {
 }
 
 #[napi]
-pub fn rmdir(path: String, options: Option<RecrusiveOptions>) -> String {
-    let options = options.unwrap_or(RecrusiveOptions {
-        recursive: Some(false)
+pub fn rmdir(path: String, options: Option<Recursive>) -> String {
+    let options = options.unwrap_or(Recursive {
+        recursive: Some(false),
     });
 
     let recursive = options.recursive.unwrap_or(false);
 
     let path = Path::new(&path);
     let error;
-    if path.exists() {
-        if recursive {
-            let message = match fs::remove_dir_all(path) {
-                Ok(()) => "ok",
-                Err(e) => {
-                    error = format!("{}", e.kind().to_string());
-                    &error
-                },
-            };
-
-            return message.to_string();
-        } else {
-            let message = match fs::remove_dir(path) {
-                Ok(()) => "ok",
-                Err(e) => {
-                    error = format!("{}", e.kind().to_string());
-                    &error
-                }
-            };
-
-            return message.to_string();
-        }
-    } else {
-        return "Invalid file".to_string()
+    if !path.exists() {
+        return "Invalid file".to_string();
     }
+
+    let result = match recursive {
+        true => fs::remove_dir_all(path),
+        false => fs::remove_dir(path),
+    };
+
+    let message = match result {
+        Ok(()) => "ok",
+        Err(e) => {
+            error = format!("{}", e.kind().to_string());
+            &error
+        }
+    };
+
+    message.to_string()
 }
 
 #[napi]
-pub fn copyfile(src: String, dest: String, options: Option<RecrusiveOptions>) -> String {
-    let options = options.unwrap_or(RecrusiveOptions {
-        recursive: Some(false)
+pub fn copyfile(src: String, dest: String, options: Option<Recursive>) -> String {
+    let options = options.unwrap_or(Recursive {
+        recursive: Some(false),
     });
 
     let recursive = options.recursive.unwrap_or(false);
@@ -88,7 +81,7 @@ fn __copyfile(src: &Path, dest: &Path) -> io::Result<u64> {
 pub fn copydir(src: String, dest: String, options: Option<CopyDirOptions>) -> String {
     let options = options.unwrap_or(CopyDirOptions {
         recursive: Some(false),
-        copy_files: Some(true)
+        copy_files: Some(true),
     });
 
     let recursive = options.recursive.unwrap_or(false);
@@ -106,22 +99,18 @@ pub fn copydir(src: String, dest: String, options: Option<CopyDirOptions>) -> St
     }
 
     if destination.exists() && recursive {
-        rmdir(destination.to_str().unwrap().to_string(), Some(RecrusiveOptions {
-            recursive: Some(true)
-        }));
+        rmdir(
+            destination.to_str().unwrap().to_string(),
+            Some(Recursive {
+                recursive: Some(true),
+            }),
+        );
     }
 
-    let error;
-    let message = match __copydir(
-        source,
-        destination,
-        recursive,
-        copy_files,
-    ) {
+    let message = match __copydir(source, destination, recursive, copy_files) {
         Ok(..) => "ok",
         Err(e) => {
-            error = format!("{}", e.kind().to_string());
-            &error
+            format!("{}", e.kind().to_string())
         }
     };
 
@@ -129,19 +118,27 @@ pub fn copydir(src: String, dest: String, options: Option<CopyDirOptions>) -> St
 }
 
 // Internal implementation for copydir function
-fn __copydir(src: impl AsRef<Path>, dest: impl AsRef<Path>, recursive: bool, copy_files: bool) -> io::Result<()> {
+fn __copydir(
+    src: impl AsRef<Path>,
+    dest: impl AsRef<Path>,
+    recursive: bool,
+    copy_files: bool,
+) -> io::Result<()> {
     fs::create_dir_all(&dest)?;
     for entry in fs::read_dir(src)? {
         let entry = entry?;
         let ty = entry.file_type()?;
         if ty.is_dir() {
-            __copydir(entry.path().to_str().unwrap().to_string(), dest.as_ref().join(entry.file_name()), recursive, copy_files)?;
+            __copydir(
+                entry.path().to_str().unwrap().to_string(),
+                dest.as_ref().join(entry.file_name()),
+                recursive,
+                copy_files,
+            )?;
         } else if copy_files {
             let dest_path = dest.as_ref().join(entry.file_name());
-            if dest_path.exists() {
-                if recursive {
-                    __copyfile(&entry.path(), &dest_path)?;
-                }
+            if dest_path.exists() && recursive {
+                __copyfile(&entry.path(), &dest_path)?;
             } else {
                 __copyfile(&entry.path(), &dest_path)?;
             }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -20,7 +20,7 @@ pub fn rmdir(path: String, options: Option<RecursiveOptions>) -> String {
     let recursive = options.recursive.unwrap_or(false);
 
     let path = Path::new(&path);
-    let error;
+
     if !path.exists() {
         return "Invalid file".to_string();
     }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -30,15 +30,10 @@ pub fn rmdir(path: String, options: Option<RecursiveOptions>) -> String {
         false => fs::remove_dir(path),
     };
 
-    let message = match result {
-        Ok(()) => "ok",
-        Err(e) => {
-            error = format!("{}", e.kind().to_string());
-            &error
-        }
-    };
-
-    message.to_string()
+    match result {
+        Ok(()) => "ok".to_string(),
+        Err(e) => format!("{}", e.kind()),
+    }
 }
 
 #[napi]
@@ -88,24 +83,22 @@ pub fn copydir(src: String, dest: String, options: Option<CopyDirOptions>) -> St
         return "Invalid source folder".to_string();
     }
 
-    if destination.exists() && !recursive {
-        return "Destination folder exists".to_string();
-    }
-
-    if destination.exists() && recursive {
-        rmdir(
-            destination.to_str().unwrap().to_string(),
-            Some(RecursiveOptions {
-                recursive: Some(true),
-            }),
-        );
+    if destination.exists() {
+        if recursive {
+            rmdir(
+                destination.to_str().unwrap().to_string(),
+                Some(RecursiveOptions {
+                    recursive: Some(true),
+                }),
+            );
+        } else {
+            return "Destination folder exists".to_string();
+        }
     }
 
     match __copydir(source, destination, recursive, copy_files) {
         Ok(..) => String::from("ok"),
-        Err(e) => {
-            format!("{}", e.kind())
-        }
+        Err(e) => format!("{}", e.kind()),
     }
 }
 

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -60,16 +60,10 @@ pub fn copyfile(src: String, dest: String, options: Option<RecursiveOptions>) ->
         return "Destination file exists".to_string();
     }
 
-    let error;
-    let message = match __copyfile(source, destination) {
-        Ok(..) => "ok",
-        Err(e) => {
-            error = format!("{}", e.kind().to_string());
-            &error
-        }
-    };
-
-    return message.to_string();
+    match __copyfile(source, destination) {
+        Ok(..) => "ok".to_string(),
+        Err(e) => format!("{}", e.kind()),
+    }
 }
 
 // Internal implementation for copyfile function

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -107,12 +107,12 @@ pub fn copydir(src: String, dest: String, options: Option<CopyDirOptions>) -> St
         );
     }
 
-    let message = match __copydir(source, destination, recursive, copy_files) {
-        Ok(..) => "ok",
-        Err(e) => format!("{}", e.kind().to_string()).as_str(),
-    };
-
-    return message.to_string();
+    match __copydir(source, destination, recursive, copy_files) {
+        Ok(..) => String::from("ok"),
+        Err(e) => {
+            format!("{}", e.kind())
+        }
+    }
 }
 
 // Internal implementation for copydir function

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,7 +1,7 @@
 use std::{fs, io, path::Path};
 
 #[napi(object)]
-pub struct Recursive {
+pub struct RecursiveOptions {
     pub recursive: Option<bool>,
 }
 
@@ -12,8 +12,8 @@ pub struct CopyDirOptions {
 }
 
 #[napi]
-pub fn rmdir(path: String, options: Option<Recursive>) -> String {
-    let options = options.unwrap_or(Recursive {
+pub fn rmdir(path: String, options: Option<RecursiveOptions>) -> String {
+    let options = options.unwrap_or(RecursiveOptions {
         recursive: Some(false),
     });
 
@@ -42,8 +42,8 @@ pub fn rmdir(path: String, options: Option<Recursive>) -> String {
 }
 
 #[napi]
-pub fn copyfile(src: String, dest: String, options: Option<Recursive>) -> String {
-    let options = options.unwrap_or(Recursive {
+pub fn copyfile(src: String, dest: String, options: Option<RecursiveOptions>) -> String {
+    let options = options.unwrap_or(RecursiveOptions {
         recursive: Some(false),
     });
 
@@ -101,7 +101,7 @@ pub fn copydir(src: String, dest: String, options: Option<CopyDirOptions>) -> St
     if destination.exists() && recursive {
         rmdir(
             destination.to_str().unwrap().to_string(),
-            Some(Recursive {
+            Some(RecursiveOptions {
                 recursive: Some(true),
             }),
         );
@@ -109,9 +109,7 @@ pub fn copydir(src: String, dest: String, options: Option<CopyDirOptions>) -> St
 
     let message = match __copydir(source, destination, recursive, copy_files) {
         Ok(..) => "ok",
-        Err(e) => {
-            format!("{}", e.kind().to_string())
-        }
+        Err(e) => format!("{}", e.kind().to_string()).as_str(),
     };
 
     return message.to_string();

--- a/src/os.rs
+++ b/src/os.rs
@@ -1,5 +1,10 @@
 //use network_interface::{Addr, NetworkInterfaceConfig};
-use systemstat::{saturating_sub_bytes, Platform};
+use lazy_static::lazy_static;
+use systemstat::{saturating_sub_bytes, Platform, System};
+
+lazy_static! {
+    static ref SYSTEM_STAT: System = System::new();
+}
 
 #[napi]
 pub fn homedir() -> Option<String> {
@@ -50,7 +55,7 @@ pub fn release() -> Option<String> {
 
 #[napi]
 pub fn uptime() -> Option<f64> {
-    match systemstat::System::new().uptime() {
+    match SYSTEM_STAT.uptime() {
         Ok(time) => Some(time.as_secs_f64()),
         Err(_) => None,
     }
@@ -87,7 +92,7 @@ pub fn cpus() -> Vec<CpuInfo> {
 
 #[napi]
 pub fn total_memory() -> Option<i64> {
-    match systemstat::System::new().memory() {
+    match SYSTEM_STAT.memory() {
         Ok(mem) => Some(mem.total.as_u64() as i64),
         Err(_) => None,
     }
@@ -95,7 +100,7 @@ pub fn total_memory() -> Option<i64> {
 
 #[napi]
 pub fn free_memory() -> Option<i64> {
-    match systemstat::System::new().memory() {
+    match SYSTEM_STAT.memory() {
         Ok(mem) => Some(saturating_sub_bytes(mem.total, mem.free).as_u64() as i64),
         Err(_) => None,
     }
@@ -103,7 +108,7 @@ pub fn free_memory() -> Option<i64> {
 
 #[napi]
 pub fn total_swap() -> Option<i64> {
-    match systemstat::System::new().swap() {
+    match SYSTEM_STAT.swap() {
         Ok(swap) => Some(swap.total.as_u64() as i64),
         Err(_) => None,
     }
@@ -111,7 +116,7 @@ pub fn total_swap() -> Option<i64> {
 
 #[napi]
 pub fn free_swap() -> Option<i64> {
-    match systemstat::System::new().swap() {
+    match SYSTEM_STAT.swap() {
         Ok(swap) => Some(saturating_sub_bytes(swap.total, swap.free).as_u64() as i64),
         Err(_) => None,
     }

--- a/src/os.rs
+++ b/src/os.rs
@@ -1,5 +1,5 @@
 //use network_interface::{Addr, NetworkInterfaceConfig};
-use systemstat::{Platform, saturating_sub_bytes};
+use systemstat::{saturating_sub_bytes, Platform};
 
 #[napi]
 pub fn homedir() -> Option<String> {
@@ -26,7 +26,7 @@ pub fn tempdir() -> String {
 pub fn hostname() -> Option<String> {
     match hostname::get() {
         Ok(name) => Some(name.to_str().unwrap().to_string()),
-        Err(..) => None,
+        Err(_) => None,
     }
 }
 
@@ -44,17 +44,15 @@ pub fn arch() -> String {
 pub fn release() -> Option<String> {
     match sys_info::os_release() {
         Ok(name) => Some(name),
-        Err(..) => None,
+        Err(_) => None,
     }
 }
 
 #[napi]
 pub fn uptime() -> Option<f64> {
-    let sys = systemstat::System::new();
-
-    match sys.uptime() {
+    match systemstat::System::new().uptime() {
         Ok(time) => Some(time.as_secs_f64()),
-        Err(..) => None
+        Err(_) => None,
     }
 }
 
@@ -63,7 +61,7 @@ pub struct CpuInfo {
     pub model: String,
     pub speed: i64,
     pub usage: f64,
-    pub ventor_id: String,
+    pub vendor_id: String,
 }
 
 #[napi]
@@ -72,13 +70,13 @@ pub fn cpus() -> Vec<CpuInfo> {
     let sys = sysinfo::System::new_with_specifics(
         sysinfo::RefreshKind::new().with_cpu(sysinfo::CpuRefreshKind::everything()),
     );
-    
+
     for cpu in sys.cpus() {
         all_cpus.push(CpuInfo {
             model: cpu.brand().to_string(),
             speed: cpu.frequency() as i64,
             usage: f64::from(cpu.cpu_usage()),
-            ventor_id: cpu.vendor_id().to_string()
+            vendor_id: cpu.vendor_id().to_string()
         })
     }
 
@@ -89,41 +87,33 @@ pub fn cpus() -> Vec<CpuInfo> {
 
 #[napi]
 pub fn total_memory() -> Option<i64> {
-    let sys = systemstat::System::new();
-
-    match sys.memory() {
+    match systemstat::System::new().memory() {
         Ok(mem) => Some(mem.total.as_u64() as i64),
-        Err(..) => None,
+        Err(_) => None,
     }
 }
 
 #[napi]
 pub fn free_memory() -> Option<i64> {
-    let sys = systemstat::System::new();
-
-    match sys.memory() {
+    match systemstat::System::new().memory() {
         Ok(mem) => Some(saturating_sub_bytes(mem.total, mem.free).as_u64() as i64),
-        Err(..) => None,
+        Err(_) => None,
     }
 }
 
 #[napi]
 pub fn total_swap() -> Option<i64> {
-    let sys = systemstat::System::new();
-
-    match sys.swap() {
+    match systemstat::System::new().swap() {
         Ok(swap) => Some(swap.total.as_u64() as i64),
-        Err(..) => None,
+        Err(_) => None,
     }
 }
 
 #[napi]
 pub fn free_swap() -> Option<i64> {
-    let sys = systemstat::System::new();
-
-    match sys.swap() {
+    match systemstat::System::new().swap() {
         Ok(swap) => Some(saturating_sub_bytes(swap.total, swap.free).as_u64() as i64),
-        Err(..) => None,
+        Err(_) => None,
     }
 }
 


### PR DESCRIPTION
Removed overused calls to `System::new()` on certain functions by making a lazily-evaluated static available inside the module.